### PR TITLE
Added support of Import-Element in MSBuild .proj files

### DIFF
--- a/LaunchPadCore/GenericScriptParser.cs
+++ b/LaunchPadCore/GenericScriptParser.cs
@@ -57,23 +57,50 @@ namespace Lextm.MSBuildLaunchPad
         {
             foreach (XmlNode node in file.DocumentElement.ChildNodes)
             {
-                if (node.Name != "Target")
+                if (node.Name == "Target")
                 {
-                    continue;
-                }
+                    if (node.Attributes == null)
+                    {
+                        continue;
+                    }
 
-                if (node.Attributes == null)
+                    XmlAttribute name = node.Attributes["Name"];
+                    if (name == null)
+                    {
+                        continue;
+                    }
+
+                    yield return name.Value;
+                }
+                else if (node.Name == "Import")
                 {
-                    continue;
-                }
+                    if (node.Attributes == null)
+                    {
+                        continue;
+                    }
 
-                XmlAttribute name = node.Attributes["Name"];
-                if (name == null)
-                {
-                    continue;
-                }
+                    XmlAttribute project = node.Attributes["Project"];
+                    if (project == null)
+                    {
+                        continue;
+                    }
 
-                yield return name.Value;
+                    XmlDocument importFile;
+
+                    try
+                    {
+                        importFile = OpenFile(project.Value);
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+
+                    foreach (var target in ParseTargets(importFile))
+                    {
+                        yield return target;
+                    }
+                }
             }
         }
 

--- a/LaunchPadCore/GenericScriptParser.cs
+++ b/LaunchPadCore/GenericScriptParser.cs
@@ -12,6 +12,18 @@ namespace Lextm.MSBuildLaunchPad
 
         public GenericScriptParser(string fileName)
         {
+            var file = OpenFile(fileName);
+
+            _version = ParseVersion(file);
+
+            foreach (var target in ParseTargets(file))
+            {
+                _list.Add(target);
+            }
+        }
+
+        private static XmlDocument OpenFile(string fileName)
+        {
             var file = new XmlDocument();
             file.Load(fileName);
             if (file.DocumentElement == null || file.DocumentElement.Name != "Project")
@@ -19,10 +31,15 @@ namespace Lextm.MSBuildLaunchPad
                 throw new ArgumentException("this is not a proj file", "fileName");
             }
 
+            return file;
+        }
+
+        private static string ParseVersion(XmlDocument file)
+        {
             string attribute = file.DocumentElement.GetAttribute("ToolsVersion");
             if (string.IsNullOrEmpty(attribute))
             {
-                _version = Tool.Tool20Version;
+                return Tool.Tool20Version;
             }
             else
             {
@@ -32,9 +49,12 @@ namespace Lextm.MSBuildLaunchPad
                     throw new ArgumentException("this is not a proj file", "fileName");
                 }
 
-                _version = element.Tool;
+                return element.Tool;
             }
+        }
 
+        private static IEnumerable<string> ParseTargets(XmlDocument file)
+        {
             foreach (XmlNode node in file.DocumentElement.ChildNodes)
             {
                 if (node.Name != "Target")
@@ -53,7 +73,7 @@ namespace Lextm.MSBuildLaunchPad
                     continue;
                 }
 
-                _list.Add(name.Value);
+                yield return name.Value;
             }
         }
 

--- a/MSBuildLaunchPad/Properties/AssemblyInfo.cs
+++ b/MSBuildLaunchPad/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.001120.24")]
-[assembly: AssemblyFileVersion("1.3.001120.24")]
+[assembly: AssemblyVersion("1.3.001121.00")]
+[assembly: AssemblyFileVersion("1.3.001121.00")]
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/MSBuildLaunchPad/Properties/AssemblyInfo.cs
+++ b/MSBuildLaunchPad/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.001120.00")]
-[assembly: AssemblyFileVersion("1.3.001120.00")]
+[assembly: AssemblyVersion("1.3.001120.06")]
+[assembly: AssemblyFileVersion("1.3.001120.06")]
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/MSBuildLaunchPad/Properties/AssemblyInfo.cs
+++ b/MSBuildLaunchPad/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.001120.06")]
-[assembly: AssemblyFileVersion("1.3.001120.06")]
+[assembly: AssemblyVersion("1.3.001120.24")]
+[assembly: AssemblyFileVersion("1.3.001120.24")]
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/MSBuildLaunchPad/Properties/AssemblyInfo.cs
+++ b/MSBuildLaunchPad/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.000417.05")]
-[assembly: AssemblyFileVersion("1.3.000417.05")]
+[assembly: AssemblyVersion("1.3.001120.00")]
+[assembly: AssemblyFileVersion("1.3.001120.00")]
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/UnitTests/GenericScriptParserTest.cs
+++ b/UnitTests/GenericScriptParserTest.cs
@@ -17,21 +17,21 @@ namespace Lextm.MSBuildLaunchPad.UnitTests
             Assert.AreEqual(6, parser.Targets.Count);
         }
 
-		[Test]
-		public void TestProjImport()
-		{
-			var tempPathName = Path.GetTempPath() + Path.GetRandomFileName();
-			Directory.CreateDirectory(tempPathName);
-			Directory.CreateDirectory(tempPathName + @"\build");
+        [Test]
+        public void TestProjImport()
+        {
+            var tempPathName = Path.GetTempPath() + Path.GetRandomFileName();
+            Directory.CreateDirectory(tempPathName);
+            Directory.CreateDirectory(tempPathName + @"\build");
 
-			var projFileName = tempPathName + @"\import.proj";
-			var targetsFileName = tempPathName + @"\build\import.targets";
-			File.WriteAllBytes(projFileName, Properties.Resources.import);
-			File.WriteAllBytes(targetsFileName, Properties.Resources.importtargets);
+            var projFileName = tempPathName + @"\import.proj";
+            var targetsFileName = tempPathName + @"\build\import.targets";
+            File.WriteAllBytes(projFileName, Properties.Resources.import);
+            File.WriteAllBytes(targetsFileName, Properties.Resources.importtargets);
 
-			var parser = new GenericScriptParser(projFileName);
-			Assert.AreEqual(Tool.Tool20Version, parser.Version);
-			Assert.AreEqual(6, parser.Targets.Count);
-		}
+            var parser = new GenericScriptParser(projFileName);
+            Assert.AreEqual(Tool.Tool20Version, parser.Version);
+            Assert.AreEqual(6, parser.Targets.Count);
+        }
     }
 }

--- a/UnitTests/GenericScriptParserTest.cs
+++ b/UnitTests/GenericScriptParserTest.cs
@@ -16,5 +16,22 @@ namespace Lextm.MSBuildLaunchPad.UnitTests
             Assert.AreEqual(Tool.Tool20Version, parser.Version);
             Assert.AreEqual(6, parser.Targets.Count);
         }
+
+		[Test]
+		public void TestProjImport()
+		{
+			var tempPathName = Path.GetTempPath() + Path.GetRandomFileName();
+			Directory.CreateDirectory(tempPathName);
+			Directory.CreateDirectory(tempPathName + @"\build");
+
+			var projFileName = tempPathName + @"\import.proj";
+			var targetsFileName = tempPathName + @"\build\import.targets";
+			File.WriteAllBytes(projFileName, Properties.Resources.import);
+			File.WriteAllBytes(targetsFileName, Properties.Resources.importtargets);
+
+			var parser = new GenericScriptParser(projFileName);
+			Assert.AreEqual(Tool.Tool20Version, parser.Version);
+			Assert.AreEqual(6, parser.Targets.Count);
+		}
     }
 }

--- a/UnitTests/Properties/Resources.Designer.cs
+++ b/UnitTests/Properties/Resources.Designer.cs
@@ -107,6 +107,26 @@ namespace Lextm.MSBuildLaunchPad.UnitTests.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
+        internal static byte[] import {
+            get {
+                object obj = ResourceManager.GetObject("import", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] importtargets {
+            get {
+                object obj = ResourceManager.GetObject("importtargets", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
         internal static byte[] Lextm_CBC2_Full {
             get {
                 object obj = ResourceManager.GetObject("Lextm_CBC2_Full", resourceCulture);

--- a/UnitTests/Properties/Resources.resx
+++ b/UnitTests/Properties/Resources.resx
@@ -148,4 +148,10 @@
   <data name="VS2015" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\VS2015.sln;System.Byte[], mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="import" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\import.proj;System.Byte[], mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="importtargets" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\import.targets;System.Byte[], mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/UnitTests/Resources/import.proj
+++ b/UnitTests/Resources/import.proj
@@ -1,0 +1,32 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import  Project=".\Deps\MSBuildCommunityTasks\MSBuild.Community.Tasks.Targets"/>
+	<PropertyGroup>
+		<MainSolution>.\MSBuildShellExtension.sln</MainSolution>
+		<NUnitPath>.\Deps\NUnit\bin\nunit-console.exe</NUnitPath>
+		<NCoverPath>.\Deps\NCover\NCover.Console.exe</NCoverPath>
+		<NSISPath>"$(ProgramFiles)\NSIS\makensis.exe"</NSISPath>
+		<TestAssembly>.\Test\bin\Debug\Test.dll</TestAssembly>
+		<ReleaseDirectory>.\release</ReleaseDirectory>
+	</PropertyGroup>
+	<Import Project=".\build\import.targets" />
+	<!--Releases a new edition of MSBuildShellExtension.
+	    Dependant of installations of subversion and nsis.
+		Also SvnBridge is required to run!-->
+	<Target Name="Release" Condition="$(Version) != ''">
+		<RemoveDir Directories="$(ReleaseDirectory)" />
+
+		<MakeDir Directories="$(ReleaseDirectory)" />
+		<SvnCheckout RepositoryPath="http://localhost:8081/msbuildshellex" LocalPath="$(ReleaseDirectory)">
+			<Output TaskParameter="Revision" PropertyName="Revision" />
+		</SvnCheckout>
+		<CreateItem Include="$(ReleaseDirectory)\MSBuildShellExtension\**\AssemblyInfo.cs;$(ReleaseDirectory)\MSBuildShellExtensionConfigurator\**\AssemblyInfo.cs">
+			<Output TaskParameter="Include" ItemName="AssemblyInfos" />
+		</CreateItem>
+		<Message Text="@(AssemblyInfos)" />
+		<!--FileUpdate Files='@(AssemblyInfos)' Regex='(?&lt;ver&gt;assembly: Assembly.*?Version\(")\d+\.\d+\.\d+\.\d+' ReplacementText='$(Version).$(Revision)' /-->
+		<Message Text="Building $(Revision) $(ReleaseDirectory)\build.proj" />
+		<MSBuild Projects="$(ReleaseDirectory)\build.proj" Targets="Rebuild;Test" />
+		<Exec Command="$(NSISPath) $(ReleaseDirectory)\install.nsi" />
+		<Copy SourceFiles="$(ReleaseDirectory)\Setup.exe" DestinationFiles=".\MSBuildShellExtension-$(Version).exe" />
+	</Target>
+</Project>

--- a/UnitTests/Resources/import.targets
+++ b/UnitTests/Resources/import.targets
@@ -1,0 +1,15 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Target Name="Build">
+		<MSBuild Projects="$(MainSolution)" Targets="Build" />
+	</Target>
+	<Target Name="Clean">
+		<MSBuild Projects="$(MainSolution)" Targets="Clean" />
+	</Target>
+	<Target Name="Rebuild" DependsOnTargets="Clean;Build" />
+	<Target Name="Test" DependsOnTargets="Build">
+		<Exec Command="$(NUnitPath) $(TestAssembly)" />
+	</Target>
+	<Target Name="Coverage" DependsOnTargets="Build">
+		<Exec Command="$(NCoverPath) $(NUnitPath) $(TestAssembly)" />
+	</Target>
+</Project>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -103,6 +103,9 @@
   <ItemGroup>
     <None Include="Resources\VS2015.sln" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -83,6 +83,8 @@
     <None Include="Resources\ExpertManager.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Resources\import.proj" />
+    <None Include="Resources\import.targets" />
     <None Include="Resources\SharpSnmpLib.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The Import-Element in MSBuild .proj files allows importing the contents of one project file in another (see [MSBuild Import Element](https://msdn.microsoft.com/en-us/library/92x05xfs.aspx)). Often the build targets are separated in another project file to re-use them. Currently GenericScriptParser parses Target-Elements only in the source project file.

1. Extended GenericScriptParser to support Import-Element
2. The extension is recursive: Contains an imported project file another import, parsing will continue in the next import
3. The extension allows relative paths in the Project-Attribute of Import-Element
4. Added an unit test that tests the Import-Element parsing extension